### PR TITLE
findOneメソッドの修正・エラーメッセージを渡すよう変更

### DIFF
--- a/src/main/java/com/example/demo/PurchaseController.java
+++ b/src/main/java/com/example/demo/PurchaseController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Controller
 public class PurchaseController {
 
-	private PurchaseService purchaseService;
+	private final PurchaseService purchaseService;
 
 	@Autowired
 	public PurchaseController(PurchaseService purchaseService) {

--- a/src/main/java/com/example/demo/PurchaseController.java
+++ b/src/main/java/com/example/demo/PurchaseController.java
@@ -25,6 +25,7 @@ public class PurchaseController {
 	public String index(Model model) {
 		model.addAttribute("purchaseList", purchaseService.getPurchaseList());
 		model.addAttribute("totalPrice", purchaseService.getTotalPrice());
+		model.addAttribute("error", "");
 		return "index";
 	}
 
@@ -37,14 +38,32 @@ public class PurchaseController {
 
 	@GetMapping("/update/{id}")
 	public String updatePurchase(@PathVariable int id, Model model) {
-		model.addAttribute("purchase", purchaseService.findOne(id));
-		return "update";
+		try {
+			model.addAttribute("purchase", purchaseService.findOne(id));
+			return "update";
+
+		} catch (Exception e) {
+			model.addAttribute("purchaseList", purchaseService.getPurchaseList());
+			model.addAttribute("totalPrice", purchaseService.getTotalPrice());
+			model.addAttribute("error", "データが登録されていません");
+			return "index";
+		}
+
 	}
 
 	@GetMapping("/delete/{id}")
 	public String deletePurchase(@PathVariable int id, Model model) {
-		model.addAttribute("purchase", purchaseService.findOne(id));
-		return "delete";
+		try {
+			model.addAttribute("purchase", purchaseService.findOne(id));
+			return "delete";
+
+		} catch (Exception e) {
+			model.addAttribute("purchaseList", purchaseService.getPurchaseList());
+			model.addAttribute("totalPrice", purchaseService.getTotalPrice());
+			model.addAttribute("error", "データが登録されていません");
+			return "index";
+		}
+
 	}
 
 	@PostMapping("/new")

--- a/src/main/java/com/example/demo/PurchaseMapper.java
+++ b/src/main/java/com/example/demo/PurchaseMapper.java
@@ -1,6 +1,7 @@
 package com.example.demo;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
@@ -9,7 +10,7 @@ public interface PurchaseMapper {
 
 	List<Purchase> findAll();
 
-	Purchase findOne(int id);
+	Optional<Purchase> findOne(int id);
 
 	int getTotalPrice();
 

--- a/src/main/java/com/example/demo/PurchaseService.java
+++ b/src/main/java/com/example/demo/PurchaseService.java
@@ -1,7 +1,6 @@
 package com.example.demo;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,12 +20,7 @@ public class PurchaseService {
 	}
 
 	public Purchase findOne(int id) throws Exception {
-		Optional<Purchase> purchaseOptional = purchaseMapper.findOne(id);
-		if (purchaseOptional.isPresent() == false) {
-			throw new Exception("データが登録されていません");
-		}
-		Purchase purchase = purchaseOptional.get();
-		return purchase;
+		return purchaseMapper.findOne(id).orElseThrow(() -> new Exception("データが登録されていません"));
 	}
 
 	public int getTotalPrice() {

--- a/src/main/java/com/example/demo/PurchaseService.java
+++ b/src/main/java/com/example/demo/PurchaseService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class PurchaseService {
 
-	private PurchaseMapper purchaseMapper;
+	private final PurchaseMapper purchaseMapper;
 
 	@Autowired
 	public PurchaseService(PurchaseMapper purchaseMapper) {

--- a/src/main/java/com/example/demo/PurchaseService.java
+++ b/src/main/java/com/example/demo/PurchaseService.java
@@ -1,6 +1,7 @@
 package com.example.demo;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -19,8 +20,13 @@ public class PurchaseService {
 		return purchaseMapper.findAll();
 	}
 
-	public Purchase findOne(int id) {
-		return purchaseMapper.findOne(id);
+	public Purchase findOne(int id) throws Exception {
+		Optional<Purchase> purchaseOptional = purchaseMapper.findOne(id);
+		if (purchaseOptional.isPresent() == false) {
+			throw new Exception("データが登録されていません");
+		}
+		Purchase purchase = purchaseOptional.get();
+		return purchase;
 	}
 
 	public int getTotalPrice() {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -150,3 +150,8 @@
 	text-align: center;
 	margin-top: 20px;
 }
+
+.error-message{
+	color: #ff0000;
+	text-align: center;
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -10,6 +10,9 @@
 		<div class="title">
 			<h1>購入リスト</h1>
 		</div>
+		<div class="error-message">
+			<p th:text="${error}"></p>
+		</div>
 		<div class="table-section">
 			<table class="purchase-table">
 				<tr>


### PR DESCRIPTION
PurchaseMapperのfindOneメソッドでOptionalを受け取るように変更し、PurchaseServiceでOptional.isPresentでチェックしてfalseの場合に例外処理を投げる。PurchaseControllerのupdatePurchaseとdeletePurchaseで例外を受け取りエラーメッセージを表示できるように変更。トップページで以下のような例外メッセージが表示される。
<img width="1130" alt="スクリーンショット 2022-06-02 18 45 31" src="https://user-images.githubusercontent.com/103230014/171605259-786c2f0d-f3bd-4134-9b91-13f4ec11671e.png">
